### PR TITLE
Typos, function descriptions

### DIFF
--- a/src/insane/iTree_summary.jl
+++ b/src/insane/iTree_summary.jl
@@ -108,7 +108,7 @@ Extract values from `lv` function at times `ts` across the tree.
     ix  = fld(bt, δt)
     tts = δt *  ix
     ttf = δt * (ix + 1.0)
-    Ix  = Int64(ix)
+    Ix  = Int64(ix) + 1
     push!(r[i], linpred(bt, tts, ttf, vt[Ix], vt[Ix+1]))
   end
 

--- a/src/insane/sim_cbd.jl
+++ b/src/insane/sim_cbd.jl
@@ -50,7 +50,7 @@ rexp(r::Float64) = @fastmath randexp()/r
 
 Return `true` if speciation event
 """
-λorμ(λ::Float64, μ::Float64) = (λ/(λ + μ)) > rand() ? true : false
+λorμ(λ::Float64, μ::Float64) = (λ/(λ + μ)) > rand()
 
 
 
@@ -94,7 +94,7 @@ function sim_cbd_b(n::Int64,
   nI = n
 
   # disjoint trees vector 
-  tv = T[]
+  tv = sTbd[]
   for i in Base.OneTo(nI)
     push!(tv, sTbd(0.0))
   end
@@ -104,13 +104,13 @@ function sim_cbd_b(n::Int64,
     w = cbd_wait(nF, λ, μ)
 
     for t in tv
-      addpe!(t, w)
+      adde!(t, w)
     end
 
     # if speciation
     if λorμ(λ, μ)
       if isone(nI)
-        return tv[nI] 
+        return tv[nI]
       else
         j, k = samp2(Base.OneTo(nI))
         tv[j] = sTbd(tv[j], tv[k], 0.0)
@@ -148,7 +148,7 @@ function sim_cbd_b(λ::Float64,
   nI = 1
 
   # disjoint trees vector 
-  tv = [sTbd(0.0, true)]
+  tv = [sTbd(0.0, false)]
 
   th = 0.0
 
@@ -168,7 +168,7 @@ function sim_cbd_b(λ::Float64,
     end
 
     for t in tv
-      addpe!(t, w)
+      adde!(t, w)
     end
 
     # if speciation

--- a/src/insane/sim_gbmbd.jl
+++ b/src/insane/sim_gbmbd.jl
@@ -36,7 +36,8 @@ Sample conditional on number of species
               p       ::Float64 = 5.0,
               warnings::Bool    = true)
 
-Simulate `iTgbmbd` according to a pure-birth geometric Brownian motion.
+Simulate `iTgbmbd` according to geometric Brownian motions for birth and death 
+rates.
 """
 function sim_gbmbd(n       ::Int64;
                    λ0      ::Float64 = 1.0,
@@ -288,7 +289,8 @@ Sample conditional on time
               nlim::Int64   = 10_000,
               init::Symbol  = :crown)
 
-Simulate `iTgbmpb` according to a pure-birth geometric Brownian motion.
+Simulate `iTgbmbd` according to geometric Brownian motions for birth and death 
+rates.
 """
 function sim_gbmbd(t   ::Float64;
                    λ0  ::Float64 = 1.0,
@@ -344,8 +346,8 @@ end
                nsp ::Int64,
                nlim::Int64)
 
-Simulate `iTgbmbd` according to a geometric Brownian motion with a limit
-on the number lineages allowed to reach.
+Simulate `iTgbmbd` according to geometric Brownian motions for birth and death 
+rates, with a limit on the number lineages allowed to reach.
 """
 function _sim_gbmbd(t   ::Float64,
                     λt  ::Float64,
@@ -448,9 +450,8 @@ end
                srδt::Float64, 
                nsp ::Int64,
                nlim::Int64)
-
-Simulate `iTgbmbd` according to a geometric Brownian motion starting 
-with a non-standard δt with a limit in the number of species.
+Simulate `iTgbmbd` according to geometric Brownian motions for birth and death 
+rates, starting with a non-standard δt with a limit in the number of species.
 """
 function _sim_gbmbd(nsδt::Float64,
                     t   ::Float64,

--- a/src/insane/sim_gbmce.jl
+++ b/src/insane/sim_gbmce.jl
@@ -30,9 +30,11 @@ Sample conditional on number of species
               μ    ::Float64 = 0.0,
               δt   ::Float64 = 1e-3,
               nstar::Int64   = 2*n,
-              p    ::Float64 = 5.0)
+              p    ::Float64 = 5.0,
+              warnings::Bool = true))
 
-Simulate `iTgbmpb` according to a pure-birth geometric Brownian motion.
+Simulate `iTgbmce` according to a geometric Brownian motion for birth rates and 
+constant extinction.
 """
 function sim_gbmce(n    ::Int64;
                    λ0   ::Float64    = 1.0, 
@@ -270,7 +272,8 @@ Sample conditional on time
               nlim::Int64   = 10_000,
               init::Symbol  = :crown)
 
-Simulate `iTgbmpb` according to a pure-birth geometric Brownian motion.
+Simulate `iTgbmce` according to a geometric Brownian motion for birth rates and 
+constant extinction.
 """
 function sim_gbmce(t   ::Float64;
                    λ0  ::Float64 = 1.0,
@@ -322,8 +325,8 @@ end
                nsp ::Int64,
                nlim::Int64)
 
-Simulate `iTgbmce` according to a geometric Brownian motion with a limit
-on the number lineages allowed to reach.
+Simulate `iTgbmce` according to a geometric Brownian motion for birth rates and 
+constant extinction, with a limit on the number lineages allowed to reach.
 """
 function _sim_gbmce(t   ::Float64,
                     λt  ::Float64,
@@ -413,8 +416,9 @@ end
               nsp ::Int64,
               nlim::Int64)
 
-Simulate `iTgbmce` according to a geometric Brownian motion starting 
-with a non-standard δt with a limit in the number of species.
+Simulate `iTgbmce` according to a geometric Brownian motion for birth rates and 
+constant extinction, starting with a non-standard δt with a limit in the number 
+of species.
 """
 function _sim_gbmce(nsδt::Float64,
                     t   ::Float64,

--- a/src/insane/sim_gbmct.jl
+++ b/src/insane/sim_gbmct.jl
@@ -34,7 +34,8 @@ Sample conditional on number of species
               p       ::Float64 = 5.0,
               warnings::Bool    = true)
 
-Simulate `iTgbmct` according to a pure-birth geometric Brownian motion.
+Simulate `iTgbmct` according to a geometric Brownian motion for birth rates and 
+constant turnover.
 """
 function sim_gbmct(n    ::Int64;
                    λ0   ::Float64    = 1.0, 
@@ -271,7 +272,8 @@ Sample conditional on time
               nlim::Int64   = 10_000,
               init::Symbol  = :crown)
 
-Simulate `iTgbmpb` according to a pure-birth geometric Brownian motion.
+Simulate `iTgbmct` according to a geometric Brownian motion for birth rates and 
+constant turnover.
 """
 function sim_gbmct(t   ::Float64;
                    λ0  ::Float64 = 1.0,
@@ -322,8 +324,8 @@ end
                nsp ::Int64,
                nlim::Int64)
 
-Simulate `iTgbmct` according to a geometric Brownian motion with a limit
-on the number lineages allowed to reach.
+Simulate `iTgbmct` according to a geometric Brownian motion for birth rates and 
+constant turnover, with a limit on the number lineages allowed to reach.
 """
 function _sim_gbmct(t   ::Float64,
                     λt  ::Float64,
@@ -416,8 +418,9 @@ end
                nsp ::Int64,
                nlim::Int64)
 
-Simulate `iTgbmct` according to a geometric Brownian motion starting 
-with a non-standard δt with a limit in the number of species.
+Simulate `iTgbmct` according to a geometric Brownian motion for birth rates and 
+constant turnover, starting with a non-standard δt with a limit in the number 
+of species.
 """
 function _sim_gbmct(nsδt::Float64,
                     t   ::Float64,


### PR DESCRIPTION
For the _time_rate! function, I added +1 to the index `Ix` because when ix is small enough compared to δt it gives Ix = 0 and you can't use it to index the vector, so I was unable to plot the rates for some trees. But I am unsure this is the right fix for the bug.